### PR TITLE
Update README to match Delta Lake implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # certstream-rust
 
-Small funemployment Rust project to build a CLI program to read the websocket stream from <https://certstream.calidog.io> and log all certificate domains to a [RocksDB](http://rocksdb.org) database, plus a small utility to dump the gathered domains from [RocksDB](http://rocksdb.org).
+Small funemployment Rust project to build a CLI program to read the websocket stream from <https://certstream.calidog.io> and log all certificate domains to a Delta Lake table.
+
+The location of the table is specified with the `TABLE_URI` environment variable and will be created automatically if it does not exist.
 
 ## Building
 
@@ -14,7 +16,6 @@ cargo build --release
 The following will put:
 
 - `certstream`
-- `dumpdoms`
 
 into `~/.cargo/bin` unless you've modified the behaviour of `cargo install`.
 
@@ -24,61 +25,23 @@ $ cargo install --git https://github.com/hrbrmstr/certstream-rust
 
 ## Read from CertStream websocket
 
+The program expects the `TABLE_URI` environment variable to contain the
+location of the Delta Lake table.  The table will be created if it does not
+already exist.
+
 ```
 USAGE:
-    certstream [OPTIONS] --dbpath <DBPATH>
+    certstream [OPTIONS]
 
 OPTIONS:
-    -d, --dbpath <DBPATH>        
     -h, --help                   Print help information
     -p, --patience <PATIENCE>    [default: 5]
     -s, --server <SERVER>        [default: wss://certstream.calidog.io/]
     -V, --version                Print version information
 ```
 
-e.g.
+Example:
 ```
-$ certstream --dbpath=~/Data/cert_doms.1 # kill or ^C to stop
-```
-
-## See the domains
-
-```
-USAGE:
-    dumpdoms --dbpath <DBPATH>
+$ TABLE_URI=./certstream.delta certstream   # press Ctrl+C to stop
 ```
 
-e.g.
-```
-$ dumpdoms --dbpath=~/Data/cert_doms.1 | tail -30
-zyw017777.direct.quickconnect.to
-zywolapki.polmedia.webd.pl
-zyx.dzign4u.com
-zyxus.keenetic.pro
-zyy.aob.mybluehost.me
-zyy.kqv.mybluehost.me
-zyyid.muo.cc
-zyzfnh.net
-zyzyxllc.com
-zz188.xyz
-zz3wd.com
-zzalale.com
-zzb.cx
-zzbolt.org
-zzdzkbuxtcwxiru62jefplj2dy.ap-southeast-2.es.amazonaws.com
-zzekasd.xyz
-zzgljy.com
-zznptabez1jijw5z.myfritz.net
-zzsmarketing.com
-zzx.admin.thinker.vc
-zzx.api.thinker.vc
-zzx.oauth.thinker.vc
-zzx52.direct.quickconnect.to
-zzyhomv.shop
-zzyzxvape.synology.me
-zzz.com.ar
-zzz.org.ua
-zzz.zzz.org.ua
-zzz4ncfxemkkuulse6ctkwzrau.eu-west-3.es.amazonaws.com
-zzzzbw.cn
-```


### PR DESCRIPTION
## Summary
- update the README to describe Delta Lake backed by `TABLE_URI`
- remove references to RocksDB, dumpdoms and `--dbpath`
- update example commands for current CLI

## Testing
- `cargo check --locked` *(fails: Could not connect to server)*